### PR TITLE
babel-preset-envをより良い感じに

### DIFF
--- a/src/scripts/index.js
+++ b/src/scripts/index.js
@@ -1,3 +1,4 @@
+import 'babel-polyfill';  // アプリ内で1度だけ読み込む エントリーポイントのてっぺん推奨
 import $ from 'jquery';
 import touchEvents from 'jquery-touch-events';
 import anime from 'animejs';

--- a/tools/webpack/base.js
+++ b/tools/webpack/base.js
@@ -11,7 +11,13 @@ import { browserslist } from '../../package.json';
 const babelOptions = {
   presets: [
     ['env', {
+      // package.jsonで指定したbrowserslistを利用する
       targets: { browsers: browserslist },
+      // babel-polyfillのうちbrowserslistを踏まえて必要なものだけ読み込む
+      useBuiltIns: true,
+      // productionの場合tree shakingを有効化
+      modules: process.env.NODE_ENV === 'production' ? false : 'commonjs',
+      // developmentの際にデバッグ情報を出力する
       debug: process.env.NODE_ENV === 'development'
     }]
   ],
@@ -24,7 +30,8 @@ const babelOptions = {
 
 const entry = {
   vendor: [
-    'babel-polyfill',
+    // useBuiltIns: trueが効かなくなるためvendorからは外す
+    // 'babel-polyfill',
     'animejs',
     'jquery',
   ],


### PR DESCRIPTION
- babel-polyfillで必要ないコードを読まないように
    - dev時にCDNから読み込んでビルド時間を短縮するテクが使えなくなったので考えもの
- tree shaking有効化
    - ES2015+形式で書かれていてどこからも使われていないコードを削除する設定を追加

てな塩梅です。